### PR TITLE
shorthand helpers for fetching js or css

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,3 +66,11 @@ module.exports = function (opts) {
         });
     });
 };
+
+module.exports.js = function() {
+    return this({ css: false, js: true });
+};
+
+module.exports.css = function() {
+    return this({ css: true, js: false });
+};

--- a/test/main.js
+++ b/test/main.js
@@ -45,6 +45,37 @@ describe("gulp-assets", function () {
         stream.end();
     });
 
+    it("should find the javascript files using shorthand helper", function (done) {
+
+        var srcFile = new gutil.File({
+                path: "test/fixtures/foo.html",
+                cwd: "test/",
+                base: "test/fixtures",
+                contents: fs.readFileSync("test/fixtures/foo.html")
+            }),
+            stream = assets.js(),
+            javascriptFiles = [];
+
+        stream.on("error", function (err) {
+            should.exist(err);
+            done(err);
+        });
+
+        stream.on("data", function (newFile) {
+            javascriptFiles.push(newFile.path);
+        });
+
+        stream.on("end", function () {
+            javascriptFiles.should.have.lengthOf(2)
+                .and.contain('test/fixtures/js/foo.js')
+                .and.contain('test/fixtures/js/bar.js');
+            done();
+        });
+
+        stream.write(srcFile);
+        stream.end();
+    });
+
     it("should find the css files", function (done) {
 
         var srcFile = new gutil.File({
@@ -57,6 +88,37 @@ describe("gulp-assets", function () {
                 js: false,
                 css: true
             }),
+            cssFiles = [];
+
+        stream.on("error", function (err) {
+            should.exist(err);
+            done(err);
+        });
+
+        stream.on("data", function (newFile) {
+            cssFiles.push(newFile.path);
+        });
+
+        stream.on("end", function () {
+            cssFiles.should.have.lengthOf(2)
+                .and.contain('test/fixtures/css/foo.css')
+                .and.contain('test/fixtures/css/bar.css');;
+            done();
+        });
+
+        stream.write(srcFile);
+        stream.end();
+    });
+
+    it("should find the css files using shorthand helper", function (done) {
+
+        var srcFile = new gutil.File({
+                path: "test/fixtures/foo.html",
+                cwd: "test/",
+                base: "test/fixtures",
+                contents: fs.readFileSync("test/fixtures/foo.html")
+            }),
+            stream = assets.css(),
             cssFiles = [];
 
         stream.on("error", function (err) {


### PR DESCRIPTION
All use cases I've found in my apps right now needs either the JS files _or_ the CSS files, not both at the same time. So I tried to create a couple of shorthand helpers, so we don't need `{ js: true }` and `{ css: true }`. I think the api looks a little less noisy:

``` javascript
var assets = require("gulp-assets");

gulp.src("./src/*.html")
    .pipe(assets.js())
    .pipe(gulp.dest("./dist"));
```
