### PR TITLE
Update deps and dotfiles

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,6 @@
 {
     "node": true,
+    "browser": false
     "esnext": true,
     "bitwise": true,
     "camelcase": true,
@@ -13,8 +14,5 @@
     "regexp": true,
     "undef": true,
     "unused": true,
-    "strict": true,
-    "trailing": true,
-    "smarttabs": true,
-    "white": true
+    "strict": true
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '0.9'
   - '0.10'
 after_script:
   npm run coveralls

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "through": "~2.3.4",
-    "gulp-util": "~2.2.0"
+    "gulp-util": "~3.0.1"
   },
   "devDependencies": {
     "event-stream": "*",
@@ -31,7 +31,7 @@
     "coveralls": "*",
     "mocha-lcov-reporter": "*",
     "istanbul": "*",
-    "should": "~2.1.0"
+    "should": "~4.0.4"
   },
   "engines": {
     "node": ">=0.8.0",

--- a/test/main.js
+++ b/test/main.js
@@ -35,9 +35,9 @@ describe("gulp-assets", function () {
         });
 
         stream.on("end", function () {
-            javascriptFiles.should.have.lengthOf(2)
-                .and.contain('test/fixtures/js/foo.js')
-                .and.contain('test/fixtures/js/bar.js');
+            javascriptFiles.should.have.lengthOf(2);
+            javascriptFiles.should.containEql('test/fixtures/js/foo.js');
+            javascriptFiles.should.containEql('test/fixtures/js/bar.js');
             done();
         });
 
@@ -66,9 +66,9 @@ describe("gulp-assets", function () {
         });
 
         stream.on("end", function () {
-            javascriptFiles.should.have.lengthOf(2)
-                .and.contain('test/fixtures/js/foo.js')
-                .and.contain('test/fixtures/js/bar.js');
+            javascriptFiles.should.have.lengthOf(2);
+            javascriptFiles.should.containEql('test/fixtures/js/foo.js');
+            javascriptFiles.should.containEql('test/fixtures/js/bar.js');
             done();
         });
 
@@ -100,9 +100,9 @@ describe("gulp-assets", function () {
         });
 
         stream.on("end", function () {
-            cssFiles.should.have.lengthOf(2)
-                .and.contain('test/fixtures/css/foo.css')
-                .and.contain('test/fixtures/css/bar.css');;
+            cssFiles.should.have.lengthOf(2);
+            cssFiles.should.containEql('test/fixtures/css/foo.css');
+            cssFiles.should.containEql('test/fixtures/css/bar.css');
             done();
         });
 
@@ -131,9 +131,9 @@ describe("gulp-assets", function () {
         });
 
         stream.on("end", function () {
-            cssFiles.should.have.lengthOf(2)
-                .and.contain('test/fixtures/css/foo.css')
-                .and.contain('test/fixtures/css/bar.css');;
+            cssFiles.should.have.lengthOf(2);
+            cssFiles.should.containEql('test/fixtures/css/foo.css');
+            cssFiles.should.containEql('test/fixtures/css/bar.css');
             done();
         });
 


### PR DESCRIPTION
- I updated [gulp-util](https://github.com/gulpjs/gulp-util) and [should.js](https://github.com/shouldjs/should.js).
  - Currently should.js doesn't have `.contain()` method but [`.containEql`](https://github.com/shouldjs/should.js#containeqlothervalue) method.
  - According to [the document](https://github.com/shouldjs/should.js#lengthnumber-and-lengthofnumber):
    
    > `.length` and `.lengthOf` change the chain's object to the given length value, so be careful when chaining!
- I updated .jshintrc. From v2.5.0, [JSHint doesn't support `trailing`, `smarttabs` and `white` options](https://github.com/jshint/jshint/releases/tag/2.5.0).
- I fixed .travis.yml.
  - I removed node `0.9` because [Travis CI doesn't support Node v0.9](http://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Choosing-Node-versions-to-test-against).
