### PR TITLE
additional transformation configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,22 +6,26 @@ var through = require('through'),
     path = require('path');
 
 module.exports = function (opts) {
+    var BASE_JS_REGEX = /<script.*?src=(?:")(.*?)(?:")/g;
+    var BASE_CSS_REGEX = /<link.*?href=(?:'|")(.*?\.css)(?:'|")/gi;
 
     opts = opts || {};
     opts.js = 'js' in opts ? opts.js : true;
     opts.css = 'css' in opts ? opts.css : false;
     opts.cwd = 'cwd' in opts ? opts.cwd : false;
+    opts.js_regex = 'js_regex' in opts ? opts.js_regex : BASE_JS_REGEX;
+    opts.css_regex = 'css_regex' in opts ? opts.css_regex : BASE_CSS_REGEX;
+    opts.clean = 'clean' in opts ? opts.clean : function(value) { return value };
 
     function findJavascriptResources(htmlStr) {
         var buildTag = typeof opts.js === 'string' ? opts.js : 'js',
             BUILD_REGEX = new RegExp('<!-- build:' + buildTag + ' -->([\\s\\S]*?)<!-- endbuild -->', 'g'),
-            JS_REGEX = /<script.*?src=(?:'|")(.*?)(?:'|")/g,
             buildStr = BUILD_REGEX.exec(htmlStr),
             resultsArray = [],
             matchArray;
 
-        while (matchArray = JS_REGEX.exec(buildStr === null ? htmlStr : buildStr[1])) {
-            resultsArray.push(matchArray[1]);
+        while (matchArray = opts.js_regex.exec(buildStr === null ? htmlStr : buildStr[1])) {
+            resultsArray.push(opts.clean(matchArray[1]));
         }
 
         return resultsArray;
@@ -30,13 +34,12 @@ module.exports = function (opts) {
     function findCSSResources(htmlStr) {
         var buildTag = typeof opts.css === 'string' ? opts.css : 'css',
             BUILD_REGEX = new RegExp('<!-- build:' + buildTag + ' -->([\\s\\S]*?)<!-- endbuild -->', 'g'),
-            CSS_REGEX = /<link.*?href=(?:'|")(.*?\.css)(?:'|")/gi,
             buildStr = BUILD_REGEX.exec(htmlStr),
             resultsArray = [],
             matchArray;
 
-        while (matchArray = CSS_REGEX.exec(buildStr === null ? htmlStr : buildStr[1])) {
-            resultsArray.push(matchArray[1]);
+        while (matchArray = opts.css_regex.exec(buildStr === null ? htmlStr : buildStr[1])) {
+            resultsArray.push(opts.clean(matchArray[1]));
         }
 
         return resultsArray;


### PR DESCRIPTION
Hi,

I have this use case where my template is using a simple template engine. I would like to use your plugin to extract css and js from this template.

however they are written with this syntax : 

```
<script src="{{ url_for('static', filename='components/moment/moment.js') }}"></script>
<script src="{{ url_for('static', filename='components/moment-timezone/builds/moment-timezone-with-data.min.js') }}"></script>
```

My proposal in this pull request is to add 3 additionnal config parameters : 
- js_regex : allow to override the default regex
- css_regex : allow to override the default regex
- clean : allow to define a function to process/transform the extracted filename from the HTML tag.

It could be used like this : 

```
assets({
        js: 'appJs',
        css: false,
        js_regex: /<script.*?src=(?:")(.*?)(?:")/g,
        clean: function(value) {
            return value.replace('\'', 'aaaaa');
       }
});
```

Please tell me if you would be willing to merge something like that. If yes, I will update my pull request with all additional documentation.

Thanks in advance

Regards
